### PR TITLE
Fix TargetFramework duplication

### DIFF
--- a/DevMirror.Service/DevMirror.Service.csproj
+++ b/DevMirror.Service/DevMirror.Service.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsService>true</UseWindowsService>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-DevMirror.Service-ac1c7a5b-af82-4b18-9342-45f5994fe809</UserSecretsId>
   </PropertyGroup>
-
-	<PropertyGroup>
-		<TargetFramework>net9.0-windows</TargetFramework>
-		<UseWindowsService>true</UseWindowsService>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
 
 	<ItemGroup>
     <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />


### PR DESCRIPTION
## Summary
- clean up DevMirror.Service.csproj by collapsing duplicate property groups

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*